### PR TITLE
refactor: clean up whitespace in useShareExport tests for consistency

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,6 +6,5 @@
   "singleQuote": true,
   "trailingComma": "es5",
   "bracketSpacing": true,
-  "jsxBracketSameLine": false,
   "arrowParens": "always"
 }

--- a/src/tests/hooks/useShareExport.test.ts
+++ b/src/tests/hooks/useShareExport.test.ts
@@ -151,10 +151,9 @@ describe('useShareExport Hook', () => {
       const { result } = renderHook(() => useShareExport(null));
       act(() => {
         result.current.setExportTab('react');
-      }); 
+      });
 
       await act(async () => {
-
         result.current.handleCopyCode(sampleAnimationConfig);
       });
 
@@ -181,7 +180,6 @@ describe('useShareExport Hook', () => {
       });
 
       await act(async () => {
-
         result.current.handleCopyCode(sampleAnimationConfig);
       });
 
@@ -219,7 +217,6 @@ describe('useShareExport Hook', () => {
       const { result } = renderHook(() => useShareExport(null));
 
       await act(async () => {
-
         return result.current.handleCopyCode(sampleAnimationConfig);
       });
       expect(result.current.error).toBe('Failed to copy code to clipboard');


### PR DESCRIPTION
This pull request includes minor changes to improve code readability and maintain consistency in configuration and testing files. The most important changes are as follows:

### Configuration Updates:
* Removed the deprecated `jsxBracketSameLine` option from the `.prettierrc` file to align with the latest Prettier configuration standards.

### Testing Code Cleanup:
* Removed unnecessary blank lines in multiple instances of the `useShareExport` hook tests in `src/tests/hooks/useShareExport.test.ts` to improve code readability and maintain a consistent style. [[1]](diffhunk://#diff-174819a826035c7dd28b360748690a8ed07abadbc09504b77a0d2aa3b417f686L157) [[2]](diffhunk://#diff-174819a826035c7dd28b360748690a8ed07abadbc09504b77a0d2aa3b417f686L184) [[3]](diffhunk://#diff-174819a826035c7dd28b360748690a8ed07abadbc09504b77a0d2aa3b417f686L222)