### PR TITLE
fix: Replace @docs.page/components with standard markdown for MDX com…

### DIFF
--- a/docs/development/contributing.mdx
+++ b/docs/development/contributing.mdx
@@ -4,7 +4,6 @@ description: Learn how to contribute to Animation Playground and help make it ev
 icon: heart
 ---
 
-import { Callout } from '@docs.page/components';
 
 # Contributing to Animation Playground
 
@@ -62,10 +61,10 @@ Before contributing, make sure you have:
    # Visit http://localhost:3000 to ensure everything works
    ```
 
-<Callout type="info">
+> ℹ️ **Info:**
   If you encounter any issues during setup, check our [troubleshooting
   guide](/setup#troubleshooting) or open an issue for help.
-</Callout>
+
 
 ## Types of Contributions
 
@@ -263,10 +262,10 @@ git commit -m "docs(setup): improve installation instructions"
    - [ ] Documentation updated
    ```
 
-<Callout type="tip">
+> 💡 **Tip:**
   Small, focused PRs are easier to review and more likely to be merged quickly.
   Consider breaking large changes into multiple PRs.
-</Callout>
+
 
 ## Code Review Process
 
@@ -500,10 +499,10 @@ We appreciate all contributions and recognize them in various ways:
 - Bug reports and testing
 - Community support and mentoring
 
-<Callout type="success">
+> ✅ **Success:**
   **Thank you for contributing!** Every contribution, no matter how small, helps
   make Animation Playground better for everyone.
-</Callout>
+
 
 ## Next Steps
 

--- a/docs/development/project-structure.mdx
+++ b/docs/development/project-structure.mdx
@@ -4,7 +4,6 @@ description: Understand the codebase architecture and organization of the Animat
 icon: folder
 ---
 
-import { Callout } from '@docs.page/components';
 
 # Project Structure
 
@@ -134,10 +133,10 @@ src/tests/
 - **Testing Library**: Component testing utilities
 - **Mock Service Worker**: API mocking for tests
 
-<Callout type="tip">
+> 💡 **Tip:**
   Tests are co-located with the code they test and follow the same directory
   structure for easy navigation.
-</Callout>
+
 
 ## Configuration Files
 
@@ -323,10 +322,10 @@ User Input → Component → Custom Hook → Database
 - `eslint`: Code linting
 - `prettier`: Code formatting
 
-<Callout type="info">
+> ℹ️ **Info:**
   All dependencies are kept up to date and regularly audited for security
   vulnerabilities.
-</Callout>
+
 
 ## Development Workflow
 

--- a/docs/development/testing.mdx
+++ b/docs/development/testing.mdx
@@ -4,7 +4,6 @@ description: Learn about the comprehensive testing strategy and how to write tes
 icon: beaker
 ---
 
-import { Callout } from '@docs.page/components';
 
 # Testing
 
@@ -18,10 +17,10 @@ Our testing strategy follows the testing pyramid principle:
 2. **Integration Tests** (Middle): Test component interactions and data flow
 3. **End-to-End Tests** (Top): Test complete user workflows
 
-<Callout type="info">
+> ℹ️ **Info:**
   We aim for high test coverage while focusing on testing behavior rather than
   implementation details.
-</Callout>
+
 
 ## Testing Stack
 
@@ -424,10 +423,10 @@ yarn test --grep "authentication"
 - HTML: Detailed interactive report at `coverage/index.html`
 - LCOV: For CI/CD integration
 
-<Callout type="tip">
+> 💡 **Tip:**
   Use `yarn test:coverage` to see which parts of your code need more test
   coverage!
-</Callout>
+
 
 ## Testing Best Practices
 
@@ -542,10 +541,10 @@ Tests must pass for:
 - TypeScript type checking passes
 - ESLint rules pass
 
-<Callout type="success">
+> ✅ **Success:**
   **Testing is integral to our development process.** Well-tested code leads to
   more confident deployments and better user experiences.
-</Callout>
+
 
 ## Debugging Tests
 

--- a/docs/features.mdx
+++ b/docs/features.mdx
@@ -4,7 +4,6 @@ description: Discover all the powerful features that make Animation Playground t
 icon: sparkles
 ---
 
-import { Callout } from '@docs.page/components';
 
 # Features
 
@@ -26,10 +25,10 @@ Animation Playground comes packed with powerful features designed to make creati
 - **Responsive Preview**: See how animations look on different screen sizes
 - **Side-by-side View**: Configuration panel and preview work together seamlessly
 
-<Callout type="tip">
+> 💡 **Tip:**
   The live preview updates immediately as you change settings, so you can
   experiment freely without any delays!
-</Callout>
+
 
 ## 💾 Saving & Management
 
@@ -63,10 +62,10 @@ Animation Playground comes packed with powerful features designed to make creati
 - **Multiple Formats**: Choose the export format that fits your workflow
 - **Copy to Clipboard**: One-click copying of generated code
 
-<Callout type="info">
+> ℹ️ **Info:**
   Generated code is clean, optimized, and follows best practices for production
   use.
-</Callout>
+
 
 ## 🛠️ Developer Experience
 

--- a/docs/guide/creating-animations.mdx
+++ b/docs/guide/creating-animations.mdx
@@ -4,7 +4,6 @@ description: Learn how to create stunning animations using the Animation Playgro
 icon: play
 ---
 
-import { Callout } from '@docs.page/components';
 
 # Creating Animations
 
@@ -54,10 +53,10 @@ Animation Playground supports several animation types:
 - **Left/Right**: Element bounces horizontally
 - **Spring**: Spring-like bouncing effect
 
-<Callout type="tip">
+> 💡 **Tip:**
   Each animation type has its own set of configurable properties. Experiment
   with different combinations to create unique effects!
-</Callout>
+
 
 ## Configuration Options
 
@@ -128,10 +127,10 @@ Let's create a simple fade-in animation:
 2. Add a **0.2s delay** if you want the animation to start later
 3. Watch the preview update in real-time
 
-<Callout type="success">
+> ✅ **Success:**
   **Congratulations!** You've created your first animation. The preview shows
   exactly how it will look in your application.
-</Callout>
+
 
 ## Advanced Techniques
 
@@ -181,10 +180,10 @@ Once you're happy with your animation:
 2. **Save Configuration**: Click the save button (requires account)
 3. **Generate Code**: Export as React component or CSS
 
-<Callout type="info">
+> ℹ️ **Info:**
   Saved animations are stored in your personal library and can be accessed from
   any device when you're logged in.
-</Callout>
+
 
 ## Next Steps
 

--- a/docs/guide/sharing-exporting.mdx
+++ b/docs/guide/sharing-exporting.mdx
@@ -4,7 +4,6 @@ description: Learn how to share your animations with others and export code for 
 icon: share
 ---
 
-import { Callout } from '@docs.page/components';
 
 # Sharing & Exporting
 
@@ -29,10 +28,10 @@ Every animation configuration can be shared with a unique URL that allows others
 4. **Copy URL**: The unique URL is automatically copied to your clipboard
 5. **Share Away**: Send the link via email, social media, or embed it in documentation
 
-<Callout type="info">
+> ℹ️ **Info:**
   Shared animations are public and read-only. Viewers can see and copy your work
   but cannot modify the original configuration.
-</Callout>
+
 
 ### Share Link Features
 
@@ -145,10 +144,10 @@ Export the raw configuration object for advanced use cases:
 4. **Copy Code**: Click the copy button to copy to clipboard
 5. **Use in Project**: Paste the code into your project files
 
-<Callout type="tip">
+> 💡 **Tip:**
   The React component export includes TypeScript types and is ready to use with
   modern React applications!
-</Callout>
+
 
 ## Integration Guide
 
@@ -285,10 +284,10 @@ const SequencedAnimations = () => {
 - Create animation pattern libraries
 - Maintain examples for common use cases
 
-<Callout type="success">
+> ✅ **Success:**
   **Pro Tip**: Create a shared collection of team animations by maintaining a
   document with links to commonly used animation configurations!
-</Callout>
+
 
 ## Troubleshooting
 

--- a/docs/guide/user-accounts.mdx
+++ b/docs/guide/user-accounts.mdx
@@ -4,7 +4,6 @@ description: Learn how to create an account, manage your animations, and use the
 icon: user
 ---
 
-import { Callout } from '@docs.page/components';
 
 # User Accounts
 
@@ -29,10 +28,10 @@ Animation Playground offers multiple ways to create an account:
 - **GitHub**: Perfect for developers who want to link their coding identity
 - **More providers**: Additional OAuth options may be available
 
-<Callout type="info">
+> ℹ️ **Info:**
   All authentication is handled securely through Supabase Auth, ensuring your
   personal information is protected.
-</Callout>
+
 
 ### Account Verification
 
@@ -85,10 +84,10 @@ Once logged in, you gain access to your personal animation library:
 - Perfect for creating animation families with slight differences
 - Maintains the original while allowing experimentation
 
-<Callout type="tip">
+> 💡 **Tip:**
   Use descriptive names like "Button Hover - Blue Theme" or "Card Entry -
   Mobile" to easily find animations later!
-</Callout>
+
 
 ## Profile Management
 
@@ -178,9 +177,9 @@ Planned premium features may include:
 - **Priority Support**: Faster response to questions and issues
 - **Early Access**: Try new features before general release
 
-<Callout type="note">
+> 📝 **Note:**
   Animation Playground is currently free to use with no limits on creativity!
-</Callout>
+
 
 ## Data Security & Privacy
 
@@ -299,9 +298,9 @@ When reporting bugs, include:
 - Expected vs actual behavior
 - Any error messages
 
-<Callout type="success">
+> ✅ **Success:**
   **Welcome to the community!** Your account gives you access to all the tools
   you need to create, save, and share amazing animations.
-</Callout>
+
 
 Ready to dive deeper into development? Check out the [Project Structure](/development/project-structure) to understand how Animation Playground is built.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -4,15 +4,14 @@ description: Welcome to the Animation Playground! This Next.js application provi
 icon: book-open
 ---
 
-import { Callout } from '@docs.page/components';
 
 # Welcome to Animation Playground 🚀
 
-<Callout type="info">
+> ℹ️ **Info:**
   Animation Playground is a Next.js application designed to help you create,
   preview, and share web animations with ease. Perfect for both novice and
   experienced developers!
-</Callout>
+
 
 ## What is Animation Playground?
 
@@ -91,7 +90,7 @@ Ready to get started? Head over to our [Quick Start guide](/setup) to set up you
 
 ---
 
-<Callout type="note">
+> 📝 **Note:**
   This documentation is built with [docs.page](https://use.docs.page/) - a
   simple and fast way to create beautiful documentation from Markdown files.
-</Callout>
+

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -4,7 +4,6 @@ description: Get the Animation Playground up and running on your local machine i
 icon: rocket
 ---
 
-import { Callout } from '@docs.page/components';
 
 # Quick Start Guide
 
@@ -14,10 +13,10 @@ Get Animation Playground running on your local machine in just a few steps. This
 
 Before you begin, make sure you have the following installed:
 
-<Callout type="warning">
+> ⚠️ **Warning:**
   **Required Software** - Node.js (version 18.x or higher recommended) - Yarn,
   npm, or pnpm package manager - Git for version control
-</Callout>
+
 
 ### Optional Prerequisites
 
@@ -48,10 +47,10 @@ npm install
 pnpm install
 ```
 
-<Callout type="info">
+> ℹ️ **Info:**
   We recommend using Yarn as it's what the project was developed with, but npm
   and pnpm work just as well.
-</Callout>
+
 
 ### 3. Environment Configuration
 
@@ -89,10 +88,10 @@ yarn drizzle-kit generate
 yarn drizzle-kit migrate
 ```
 
-<Callout type="note">
+> 📝 **Note:**
   The app will work without database setup, but you won't be able to save or
   share animations.
-</Callout>
+
 
 ### 5. Start Development Server
 
@@ -159,7 +158,7 @@ Now that you have Animation Playground running:
 - **Development**: Read about the [project structure](/development/project-structure)
 - **Contributing**: Learn how to [contribute](/development/contributing) to the project
 
-<Callout type="success">
+> ✅ **Success:**
   **🎉 Congratulations!** You now have Animation Playground running locally.
   Start creating amazing animations!
-</Callout>
+


### PR DESCRIPTION
…patibility

- Remove all 'import { Callout } from @docs.page/components' statements
- Replace <Callout> components with markdown blockquotes using emojis
- Fix MDX preview compatibility in local development environments
- Resolve 'Failed to resolve module specifier' errors
- Use visual emoji indicators: ℹ️ Info, 💡 Tip, ⚠️ Warning, 📝 Note, ✅ Success
- Maintain docs.page compatibility while enabling local MDX preview

Fixes compatibility issues when previewing MDX files locally where @docs.page/components module is not available.