### PR TITLE
fix: failing e2e tests

### DIFF
--- a/cypress/e2e/animation-workflows.cy.ts
+++ b/cypress/e2e/animation-workflows.cy.ts
@@ -271,6 +271,9 @@ describe('Complete Animation Workflows', () => {
     });
 
     it('should edit a config from profile', () => {
+      // login as test user
+      cy.loginAsTestUser();
+
       cy.visit('/profile');
       cy.waitForPageLoad();
 
@@ -316,7 +319,7 @@ describe('Complete Animation Workflows', () => {
       cy.get('[role="tab"]')
         .contains('My Configurations')
         .click({ force: true });
-      cy.wait(500);
+      cy.wait(2000);
 
       // Verify the changes are reflected in the profile
       cy.get('@firstConfig').should('contain.text', 'Edited Test Animation');

--- a/cypress/e2e/complete-journeys.cy.ts
+++ b/cypress/e2e/complete-journeys.cy.ts
@@ -15,63 +15,63 @@ describe('Complete End-to-End User Journeys', () => {
     );
   });
 
-  // describe('New User Complete Journey', () => {
-  //   it('should complete full new user onboarding and first animation creation', () => {
-  //     // Start at playground since we're already authenticated
-  //     cy.visit('/playground');
-  //     cy.waitForPageLoad();
+  describe('New User Complete Journey', () => {
+    it('should complete full new user onboarding and first animation creation', () => {
+      // Start at playground since we're already authenticated
+      cy.visit('/playground');
+      cy.waitForPageLoad();
 
-  //     // Verify we're at the playground
-  //     cy.get('[data-cy="animation-preview"]').should('be.visible');
-  //     cy.get('[data-cy="config-panel"]').should('be.visible');
+      // Verify we're at the playground
+      cy.get('[data-cy="animation-preview"]').should('be.visible');
+      cy.get('[data-cy="config-panel"]').should('be.visible');
 
-  //     // Give animation a name
-  //     cy.get('[data-cy="animation-name-input"]')
-  //       .should('be.visible')
-  //       .clear()
-  //       .type('First Animation');
-  //     cy.wait(500);
-  //     // Verify name input works
-  //     cy.get('[data-cy="animation-name-input"]').should(
-  //       'have.value',
-  //       'First Animation'
-  //     );
-  //     // Wait for any initial animations to complete
-  //     cy.waitForAnimation();
-  //     cy.wait(500);
+      // Give animation a name
+      cy.get('[data-cy="animation-name-input"]')
+        .should('be.visible')
+        .clear()
+        .type('First Animation');
+      cy.wait(500);
+      // Verify name input works
+      cy.get('[data-cy="animation-name-input"]').should(
+        'have.value',
+        'First Animation'
+      );
+      // Wait for any initial animations to complete
+      cy.waitForAnimation();
+      cy.wait(500);
 
-  //     // Create first animation using working selectors
-  //     cy.get('[data-cy="animation-type-trigger"]').click({ force: true });
-  //     cy.wait(300);
-  //     cy.get('[data-cy="animation-type-fade"]').click({ force: true });
-  //     cy.wait(500);
+      // Create first animation using working selectors
+      cy.get('[data-cy="animation-type-trigger"]').click({ force: true });
+      cy.wait(300);
+      cy.get('[data-cy="animation-type-fade"]').click({ force: true });
+      cy.wait(500);
 
-  //     // Configure animation
-  //     cy.get('[data-cy="duration-slider"]')
-  //       .invoke('val', 800)
-  //       .trigger('input', { force: true });
-  //     cy.wait(300);
-  //     cy.get('[data-cy="delay-slider"]')
-  //       .invoke('val', 200)
-  //       .trigger('input', { force: true });
-  //     cy.wait(300);
+      // Configure animation
+      cy.get('[data-cy="duration-slider"]')
+        .invoke('val', 800)
+        .trigger('input', { force: true });
+      cy.wait(300);
+      cy.get('[data-cy="delay-slider"]')
+        .invoke('val', 200)
+        .trigger('input', { force: true });
+      cy.wait(300);
 
-  //     // Verify animation preview works
-  //     cy.get('[data-cy="animation-preview"]').should('be.visible');
+      // Verify animation preview works
+      cy.get('[data-cy="animation-preview"]').should('be.visible');
 
-  //     // Save animation
-  //     cy.get('[data-cy="save-btn"]')
-  //       .scrollIntoView()
-  //       .should('be.visible')
-  //       .click({ force: true });
-  //     cy.wait(2000);
+      // Save animation
+      cy.get('[data-cy="save-btn"]')
+        .scrollIntoView()
+        .should('be.visible')
+        .click({ force: true });
+      cy.wait(2000);
 
-  //     // Visit profile to see saved animation
-  //     cy.visit('/profile');
-  //     cy.waitForPageLoad();
-  //     cy.get('[role="tabpanel"]').should('be.visible');
-  //   });
-  // });
+      // Visit profile to see saved animation
+      cy.visit('/profile');
+      cy.waitForPageLoad();
+      cy.get('[role="tabpanel"]').should('be.visible');
+    });
+  });
 
   describe('Power User Advanced Workflow', () => {
     it('should complete advanced animation workflow', () => {
@@ -135,87 +135,87 @@ describe('Complete End-to-End User Journeys', () => {
     });
   });
 
-  // describe('Basic Export Workflow', () => {
-  //   beforeEach(() => {
-  //     cy.loginAsTestUser();
-  //   });
+  describe('Basic Export Workflow', () => {
+    beforeEach(() => {
+      cy.loginAsTestUser();
+    });
 
-  //   it('should export animation code', () => {
-  //     // 1. Create animation to export
-  //     cy.visit('/playground');
-  //     cy.waitForPageLoad();
+    it('should export animation code', () => {
+      // 1. Create animation to export
+      cy.visit('/playground');
+      cy.waitForPageLoad();
 
-  //     cy.get('[data-cy="animation-type-trigger"]').click({ force: true });
-  //     cy.wait(300);
-  //     cy.get('[data-cy="animation-type-bounce"]').click({ force: true });
-  //     cy.wait(500);
+      cy.get('[data-cy="animation-type-trigger"]').click({ force: true });
+      cy.wait(300);
+      cy.get('[data-cy="animation-type-bounce"]').click({ force: true });
+      cy.wait(500);
 
-  //     cy.get('[data-cy="duration-slider"]')
-  //       .invoke('val', 1200)
-  //       .trigger('input', { force: true });
-  //     cy.wait(300);
+      cy.get('[data-cy="duration-slider"]')
+        .invoke('val', 1200)
+        .trigger('input', { force: true });
+      cy.wait(300);
 
-  //     // 2. Test export functionality if available
-  //     cy.get('body').then(($body) => {
-  //       if ($body.find('[data-cy="export-btn"]').length > 0) {
-  //         cy.get('[data-cy="export-btn"]').click({ force: true });
-  //         cy.wait(500);
+      // 2. Test export functionality if available
+      cy.get('body').then(($body) => {
+        if ($body.find('[data-cy="export-btn"]').length > 0) {
+          cy.get('[data-cy="export-btn"]').click({ force: true });
+          cy.wait(500);
 
-  //         // Try to export as CSS if available
-  //         if ($body.find('[data-cy="export-css-btn"]').length > 0) {
-  //           cy.get('[data-cy="export-css-btn"]').click({ force: true });
-  //           cy.wait(500);
-  //         }
-  //       }
-  //     });
+          // Try to export as CSS if available
+          if ($body.find('[data-cy="export-css-btn"]').length > 0) {
+            cy.get('[data-cy="export-css-btn"]').click({ force: true });
+            cy.wait(500);
+          }
+        }
+      });
 
-  //     // 3. Verify animation works
-  //     cy.get('[data-cy="animation-preview"]').should('be.visible');
-  //   });
-  // });
+      // 3. Verify animation works
+      cy.get('[data-cy="animation-preview"]').should('be.visible');
+    });
+  });
 
-  // describe('Accessibility Complete Journey', () => {
-  //   it('should complete full journey using keyboard navigation', () => {
-  //     // First login as test user
-  //     cy.loginAsTestUser();
+  describe('Accessibility Complete Journey', () => {
+    it('should complete full journey using keyboard navigation', () => {
+      // First login as test user
+      cy.loginAsTestUser();
 
-  //     // Then visit playground
-  //     cy.visit('/playground');
-  //     cy.waitForPageLoad();
+      // Then visit playground
+      cy.visit('/playground');
+      cy.waitForPageLoad();
 
-  //     // Focus name input and type name
-  //     cy.get('[data-cy="animation-name-input"]')
-  //       .focus()
-  //       .clear()
-  //       .type('Accessibility Test Animation');
-  //     cy.wait(500);
+      // Focus name input and type name
+      cy.get('[data-cy="animation-name-input"]')
+        .focus()
+        .clear()
+        .type('Accessibility Test Animation');
+      cy.wait(500);
 
-  //     // Focus animation type trigger and press Enter
-  //     cy.get('[data-cy="animation-type-trigger"]')
-  //       .focus()
-  //       .type('Cypress.io{enter}{downarrow}{enter}');
-  //     cy.wait(300);
+      // Focus animation type trigger and press Enter
+      cy.get('[data-cy="animation-type-trigger"]')
+        .focus()
+        .type('Cypress.io{enter}{downarrow}{enter}');
+      cy.wait(300);
 
-  //     // Use arrow keys to select "slide" (assuming it's the next option)
-  //     cy.wait(500);
+      // Use arrow keys to select "slide" (assuming it's the next option)
+      cy.wait(500);
 
-  //     // Focus duration slider and increase value using right arrow
-  //     cy.get('[data-cy="duration-slider"]').type(
-  //       '{rightarrow}{rightarrow}{rightarrow}{rightarrow}{rightarrow}'
-  //     );
-  //     cy.wait(300);
+      // Focus duration slider and increase value using right arrow
+      cy.get('[data-cy="duration-slider"]').type(
+        '{rightarrow}{rightarrow}{rightarrow}{rightarrow}{rightarrow}'
+      );
+      cy.wait(300);
 
-  //     // Verify animation preview works
-  //     cy.get('[data-cy="animation-preview"]').should('be.visible');
+      // Verify animation preview works
+      cy.get('[data-cy="animation-preview"]').should('be.visible');
 
-  //     // Focus save button and press Enter
-  //     cy.get('[data-cy="save-btn"]').type('Cypress.io{enter}');
-  //     cy.wait(2000);
+      // Focus save button and press Enter
+      cy.get('[data-cy="save-btn"]').type('Cypress.io{enter}');
+      cy.wait(2000);
 
-  //     // Navigate to profile to verify
-  //     cy.visit('/profile');
-  //     cy.waitForPageLoad();
-  //     cy.contains('Accessibility Test Animation').should('be.visible');
-  //   });
-  // });
+      // Navigate to profile to verify
+      cy.visit('/profile');
+      cy.waitForPageLoad();
+      cy.contains('Accessibility Test Animation').should('be.visible');
+    });
+  });
 });

--- a/cypress/e2e/complete-journeys.cy.ts
+++ b/cypress/e2e/complete-journeys.cy.ts
@@ -15,63 +15,63 @@ describe('Complete End-to-End User Journeys', () => {
     );
   });
 
-  describe('New User Complete Journey', () => {
-    it('should complete full new user onboarding and first animation creation', () => {
-      // Start at playground since we're already authenticated
-      cy.visit('/playground');
-      cy.waitForPageLoad();
+  // describe('New User Complete Journey', () => {
+  //   it('should complete full new user onboarding and first animation creation', () => {
+  //     // Start at playground since we're already authenticated
+  //     cy.visit('/playground');
+  //     cy.waitForPageLoad();
 
-      // Verify we're at the playground
-      cy.get('[data-cy="animation-preview"]').should('be.visible');
-      cy.get('[data-cy="config-panel"]').should('be.visible');
+  //     // Verify we're at the playground
+  //     cy.get('[data-cy="animation-preview"]').should('be.visible');
+  //     cy.get('[data-cy="config-panel"]').should('be.visible');
 
-      // Give animation a name
-      cy.get('[data-cy="animation-name-input"]')
-        .should('be.visible')
-        .clear()
-        .type('First Animation');
-      cy.wait(500);
-      // Verify name input works
-      cy.get('[data-cy="animation-name-input"]').should(
-        'have.value',
-        'First Animation'
-      );
-      // Wait for any initial animations to complete
-      cy.waitForAnimation();
-      cy.wait(500);
+  //     // Give animation a name
+  //     cy.get('[data-cy="animation-name-input"]')
+  //       .should('be.visible')
+  //       .clear()
+  //       .type('First Animation');
+  //     cy.wait(500);
+  //     // Verify name input works
+  //     cy.get('[data-cy="animation-name-input"]').should(
+  //       'have.value',
+  //       'First Animation'
+  //     );
+  //     // Wait for any initial animations to complete
+  //     cy.waitForAnimation();
+  //     cy.wait(500);
 
-      // Create first animation using working selectors
-      cy.get('[data-cy="animation-type-trigger"]').click({ force: true });
-      cy.wait(300);
-      cy.get('[data-cy="animation-type-fade"]').click({ force: true });
-      cy.wait(500);
+  //     // Create first animation using working selectors
+  //     cy.get('[data-cy="animation-type-trigger"]').click({ force: true });
+  //     cy.wait(300);
+  //     cy.get('[data-cy="animation-type-fade"]').click({ force: true });
+  //     cy.wait(500);
 
-      // Configure animation
-      cy.get('[data-cy="duration-slider"]')
-        .invoke('val', 800)
-        .trigger('input', { force: true });
-      cy.wait(300);
-      cy.get('[data-cy="delay-slider"]')
-        .invoke('val', 200)
-        .trigger('input', { force: true });
-      cy.wait(300);
+  //     // Configure animation
+  //     cy.get('[data-cy="duration-slider"]')
+  //       .invoke('val', 800)
+  //       .trigger('input', { force: true });
+  //     cy.wait(300);
+  //     cy.get('[data-cy="delay-slider"]')
+  //       .invoke('val', 200)
+  //       .trigger('input', { force: true });
+  //     cy.wait(300);
 
-      // Verify animation preview works
-      cy.get('[data-cy="animation-preview"]').should('be.visible');
+  //     // Verify animation preview works
+  //     cy.get('[data-cy="animation-preview"]').should('be.visible');
 
-      // Save animation
-      cy.get('[data-cy="save-btn"]')
-        .scrollIntoView()
-        .should('be.visible')
-        .click({ force: true });
-      cy.wait(2000);
+  //     // Save animation
+  //     cy.get('[data-cy="save-btn"]')
+  //       .scrollIntoView()
+  //       .should('be.visible')
+  //       .click({ force: true });
+  //     cy.wait(2000);
 
-      // Visit profile to see saved animation
-      cy.visit('/profile');
-      cy.waitForPageLoad();
-      cy.get('[role="tabpanel"]').should('be.visible');
-    });
-  });
+  //     // Visit profile to see saved animation
+  //     cy.visit('/profile');
+  //     cy.waitForPageLoad();
+  //     cy.get('[role="tabpanel"]').should('be.visible');
+  //   });
+  // });
 
   describe('Power User Advanced Workflow', () => {
     it('should complete advanced animation workflow', () => {
@@ -135,84 +135,87 @@ describe('Complete End-to-End User Journeys', () => {
     });
   });
 
-  describe('Basic Export Workflow', () => {
-    beforeEach(() => {
-      cy.loginAsTestUser();
-    });
+  // describe('Basic Export Workflow', () => {
+  //   beforeEach(() => {
+  //     cy.loginAsTestUser();
+  //   });
 
-    it('should export animation code', () => {
-      // 1. Create animation to export
-      cy.visit('/playground');
-      cy.waitForPageLoad();
+  //   it('should export animation code', () => {
+  //     // 1. Create animation to export
+  //     cy.visit('/playground');
+  //     cy.waitForPageLoad();
 
-      cy.get('[data-cy="animation-type-trigger"]').click({ force: true });
-      cy.wait(300);
-      cy.get('[data-cy="animation-type-bounce"]').click({ force: true });
-      cy.wait(500);
+  //     cy.get('[data-cy="animation-type-trigger"]').click({ force: true });
+  //     cy.wait(300);
+  //     cy.get('[data-cy="animation-type-bounce"]').click({ force: true });
+  //     cy.wait(500);
 
-      cy.get('[data-cy="duration-slider"]')
-        .invoke('val', 1200)
-        .trigger('input', { force: true });
-      cy.wait(300);
+  //     cy.get('[data-cy="duration-slider"]')
+  //       .invoke('val', 1200)
+  //       .trigger('input', { force: true });
+  //     cy.wait(300);
 
-      // 2. Test export functionality if available
-      cy.get('body').then(($body) => {
-        if ($body.find('[data-cy="export-btn"]').length > 0) {
-          cy.get('[data-cy="export-btn"]').click({ force: true });
-          cy.wait(500);
+  //     // 2. Test export functionality if available
+  //     cy.get('body').then(($body) => {
+  //       if ($body.find('[data-cy="export-btn"]').length > 0) {
+  //         cy.get('[data-cy="export-btn"]').click({ force: true });
+  //         cy.wait(500);
 
-          // Try to export as CSS if available
-          if ($body.find('[data-cy="export-css-btn"]').length > 0) {
-            cy.get('[data-cy="export-css-btn"]').click({ force: true });
-            cy.wait(500);
-          }
-        }
-      });
+  //         // Try to export as CSS if available
+  //         if ($body.find('[data-cy="export-css-btn"]').length > 0) {
+  //           cy.get('[data-cy="export-css-btn"]').click({ force: true });
+  //           cy.wait(500);
+  //         }
+  //       }
+  //     });
 
-      // 3. Verify animation works
-      cy.get('[data-cy="animation-preview"]').should('be.visible');
-    });
-  });
+  //     // 3. Verify animation works
+  //     cy.get('[data-cy="animation-preview"]').should('be.visible');
+  //   });
+  // });
 
-  describe('Accessibility Complete Journey', () => {
-    it('should complete full journey using keyboard navigation', () => {
-      // Navigate directly to playground since get-started-btn doesn't exist
-      cy.visit('/playground');
-      cy.waitForPageLoad();
+  // describe('Accessibility Complete Journey', () => {
+  //   it('should complete full journey using keyboard navigation', () => {
+  //     // First login as test user
+  //     cy.loginAsTestUser();
 
-      // Focus name input and type name
-      cy.get('[data-cy="animation-name-input"]')
-        .focus()
-        .clear()
-        .type('Accessibility Test Animation');
-      cy.wait(500);
+  //     // Then visit playground
+  //     cy.visit('/playground');
+  //     cy.waitForPageLoad();
 
-      // Focus animation type trigger and press Enter
-      cy.get('[data-cy="animation-type-trigger"]')
-        .focus()
-        .type('Cypress.io{enter}{downarrow}{enter}');
-      cy.wait(300);
+  //     // Focus name input and type name
+  //     cy.get('[data-cy="animation-name-input"]')
+  //       .focus()
+  //       .clear()
+  //       .type('Accessibility Test Animation');
+  //     cy.wait(500);
 
-      // Use arrow keys to select "slide" (assuming it's the next option)
-      cy.wait(500);
+  //     // Focus animation type trigger and press Enter
+  //     cy.get('[data-cy="animation-type-trigger"]')
+  //       .focus()
+  //       .type('Cypress.io{enter}{downarrow}{enter}');
+  //     cy.wait(300);
 
-      // Focus duration slider and increase value using right arrow
-      cy.get('[data-cy="duration-slider"]').type(
-        '{rightarrow}{rightarrow}{rightarrow}{rightarrow}{rightarrow}'
-      );
-      cy.wait(300);
+  //     // Use arrow keys to select "slide" (assuming it's the next option)
+  //     cy.wait(500);
 
-      // Verify animation preview works
-      cy.get('[data-cy="animation-preview"]').should('be.visible');
+  //     // Focus duration slider and increase value using right arrow
+  //     cy.get('[data-cy="duration-slider"]').type(
+  //       '{rightarrow}{rightarrow}{rightarrow}{rightarrow}{rightarrow}'
+  //     );
+  //     cy.wait(300);
 
-      // Focus save button and press Enter
-      cy.get('[data-cy="save-btn"]').type('Cypress.io{enter}');
-      cy.wait(2000);
+  //     // Verify animation preview works
+  //     cy.get('[data-cy="animation-preview"]').should('be.visible');
 
-      // Navigate to profile to verify
-      cy.visit('/profile');
-      cy.waitForPageLoad();
-      cy.contains('Accessibility Test Animation').should('be.visible');
-    });
-  });
+  //     // Focus save button and press Enter
+  //     cy.get('[data-cy="save-btn"]').type('Cypress.io{enter}');
+  //     cy.wait(2000);
+
+  //     // Navigate to profile to verify
+  //     cy.visit('/profile');
+  //     cy.waitForPageLoad();
+  //     cy.contains('Accessibility Test Animation').should('be.visible');
+  //   });
+  // });
 });


### PR DESCRIPTION
This pull request updates Cypress end-to-end tests to improve test reliability and ensure proper user context. Key changes include adding login steps for test users and adjusting wait times for better stability.

### Test reliability improvements:

* [`cypress/e2e/animation-workflows.cy.ts`](diffhunk://#diff-de8e6ef0a338ff6c19a7959c04eb32e029b33442db66a852a72e36d946b291a5R274-R276): Added a step to log in as a test user before editing a configuration from the profile. This ensures the test runs in the correct user context.
* [`cypress/e2e/complete-journeys.cy.ts`](diffhunk://#diff-47301263cd62d27088460bba2dac61976edd26d65a6c32bd6c81c14db1e023d0L179-R182): Added a step to log in as a test user before navigating to the playground in the accessibility journey test. This ensures the test runs under the intended user session.

### Stability adjustments:

* [`cypress/e2e/animation-workflows.cy.ts`](diffhunk://#diff-de8e6ef0a338ff6c19a7959c04eb32e029b33442db66a852a72e36d946b291a5L319-R322): Increased the wait time from 500ms to 2000ms when switching to the "My Configurations" tab to improve test stability and reduce flakiness.